### PR TITLE
Removed callback to closeTimer when closing the overlay.

### DIFF
--- a/app/src/main/java/codes/simen/l50notifications/OverlayServiceCommon.java
+++ b/app/src/main/java/codes/simen/l50notifications/OverlayServiceCommon.java
@@ -1,3 +1,18 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package codes.simen.l50notifications;
 
 import android.animation.Animator;
@@ -756,6 +771,7 @@ public class OverlayServiceCommon extends Service implements SensorEventListener
     }
 
     private void doFinish(final int doDismiss) { // 0=ikke fjern 1=fjern 2=åpnet
+        handler.removeCallbacks(closeTimer);
         if (Build.VERSION.SDK_INT >= 12) {
             try {
                 View self = layout.findViewById(R.id.notificationbg);


### PR DESCRIPTION
The issue seems to be caused by the policyManager.lockNow(); command being called a few seconds after the screen is unlocked. After removing callback to closeTimer when closing the overlay, I was not able to reproduce the issue.
